### PR TITLE
Show short opt alias in `--help`

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -220,9 +220,14 @@ print_app_help <- function(app, yaml = TRUE) {
     if (opt$arg_type == "option") {
       default <- opt$default
       type <- opt$val_type
+      short_name <- opt$short
       if (type == "string")
         default <- deparse1(default)
-      header <- sprintf("  --%s <value>  (Default: %s, Type: %s)", name, default, type)
+      header <- if (is.null(short_name)) {
+        sprintf("  --%s <value>  (Default: %s, Type: %s)", name, default, type)
+      } else {
+        sprintf("  -%s, --%s <value>  (Default: %s, Type: %s)", short_name, name, default, type)
+      }
       description <- if (length(opt$description))
         strwrap(opt$description, 70, indent = 6, exdent = 6)
       out <- paste0(c(header, description), collapse = "\n")

--- a/tests/testthat/_snaps/basics.md
+++ b/tests/testthat/_snaps/basics.md
@@ -1,0 +1,16 @@
+# examples work
+
+    Code
+      writeLines(run_app("flip-coin.R --help"))
+    Output
+      Flip a coin.
+      
+      Usage: flip-coin [options]
+      
+      Options:
+        -n, --flips <value>  (Default: 1, Type: integer)
+            Number of coin flips
+        --sep <value>  (Default: " ", Type: string)
+        --wrap | --no-wrap  (Default: --wrap)
+        --seed <value>  (Default: NA, Type: integer)
+

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -43,7 +43,7 @@ test_that("examples work", {
   )
 
   expect_all_equal <- function(...) {
-    if(...length()<2) stop("not enough args")
+    if(...length() < 2) stop("not enough args")
     for(i in 2:...length()) {
       expect_equal(..1, ...elt(i))
     }

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -57,4 +57,8 @@ test_that("examples work", {
     run_app("flip-coin.R -n 3 --seed=1234")
   )
 
+  expect_snapshot(
+    writeLines(run_app("flip-coin.R --help"))
+  )
+
 })


### PR DESCRIPTION
Update `--help` output to show the short option name. Followup to #5. 

