### PR TITLE
Avoid Windows PATH registry changes in tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Rapp (development version)
 
--   Running tests no longer modifies the user `PATH` on Windows.
+-   Running tests no longer modifies the user `PATH` on Windows (#26).
 
 # Rapp 0.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Rapp (development version)
 
+-   Running tests no longer modifies the user `PATH` on Windows.
+
 # Rapp 0.3.0
 
 ## Breaking changes

--- a/R/install.R
+++ b/R/install.R
@@ -473,17 +473,20 @@ ensure_path_windows <- function(destdir = rapp_install_dir()) {
   if (Sys.getenv("RAPP_NO_MODIFY_PATH") != "") {
     return(FALSE)
   }
-  stopifnot(.Platform$OS.type == "windows")
+  stopifnot(is_windows())
   destdir <- normalizePath(destdir, winslash = "\\", mustWork = TRUE)
 
   # Check if we're already on PATH. If we are, do nothing
+  path_norm <- function(x) tolower(normalizePath(x, mustWork = FALSE))
+  present <- path_norm(destdir) %in% path_norm(split_path(Sys.getenv("PATH")))
+  if (present) {
+    return(FALSE)
+  }
+
   # Read current PATH from HKCU\Environment
   path <- get_env_win_registry("Path")
-  path <- strsplit(path, ";", fixed = TRUE)[[1L]]
-  path <- path[nzchar(path)]
-  path <- unique(path)
+  path <- split_path(path)
 
-  path_norm <- function(x) tolower(normalizePath(x, mustWork = FALSE))
   present <- path_norm(destdir) %in% path_norm(path)
   if (present) {
     return(FALSE)
@@ -508,6 +511,11 @@ ensure_path_windows <- function(destdir = rapp_install_dir()) {
   ))
   args <- c("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script)
   system2("powershell", args)
+}
+
+split_path <- function(path) {
+  path <- strsplit(path, ";", fixed = TRUE)[[1L]]
+  unique(path[nzchar(path)])
 }
 
 get_env_win_registry <- function(name) {

--- a/R/install.R
+++ b/R/install.R
@@ -473,20 +473,17 @@ ensure_path_windows <- function(destdir = rapp_install_dir()) {
   if (Sys.getenv("RAPP_NO_MODIFY_PATH") != "") {
     return(FALSE)
   }
-  stopifnot(is_windows())
+  stopifnot(.Platform$OS.type == "windows")
   destdir <- normalizePath(destdir, winslash = "\\", mustWork = TRUE)
 
   # Check if we're already on PATH. If we are, do nothing
-  path_norm <- function(x) tolower(normalizePath(x, mustWork = FALSE))
-  present <- path_norm(destdir) %in% path_norm(split_path(Sys.getenv("PATH")))
-  if (present) {
-    return(FALSE)
-  }
-
   # Read current PATH from HKCU\Environment
   path <- get_env_win_registry("Path")
-  path <- split_path(path)
+  path <- strsplit(path, ";", fixed = TRUE)[[1L]]
+  path <- path[nzchar(path)]
+  path <- unique(path)
 
+  path_norm <- function(x) tolower(normalizePath(x, mustWork = FALSE))
   present <- path_norm(destdir) %in% path_norm(path)
   if (present) {
     return(FALSE)
@@ -511,11 +508,6 @@ ensure_path_windows <- function(destdir = rapp_install_dir()) {
   ))
   args <- c("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script)
   system2("powershell", args)
-}
-
-split_path <- function(path) {
-  path <- strsplit(path, ";", fixed = TRUE)[[1L]]
-  unique(path[nzchar(path)])
 }
 
 get_env_win_registry <- function(name) {

--- a/tests/testthat/test-help-snapshots.R
+++ b/tests/testthat/test-help-snapshots.R
@@ -63,30 +63,14 @@ withr::local_envvar(R_PROFILE_USER = pkg_profile, .local_envir = snapshot_env)
 destdir <- tempfile("rapp-help-bin")
 dir.create(destdir, recursive = TRUE, showWarnings = FALSE)
 withr::defer(unlink(destdir, recursive = TRUE), envir = snapshot_env)
-
-old_no_modify <- Sys.getenv("RAPP_NO_MODIFY_PATH", unset = NA_character_)
-Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
-withr::defer(
-  {
-    if (is.na(old_no_modify)) {
-      Sys.unsetenv("RAPP_NO_MODIFY_PATH")
-    } else {
-      Sys.setenv("RAPP_NO_MODIFY_PATH", old_no_modify)
-    }
-  },
-  envir = snapshot_env
-)
-
-withr::with_envvar(c("RAPP_NO_MODIFY_PATH" = "1"), {
-  suppressMessages(Rapp::install_pkg_cli_apps(
-    pkg,
-    destdir = destdir,
-    lib.loc = fake[["lib"]],
-    overwrite = TRUE
-  ))
-})
-
 withr::local_path(destdir, .local_envir = snapshot_env)
+
+suppressMessages(Rapp::install_pkg_cli_apps(
+  pkg,
+  destdir = destdir,
+  lib.loc = fake[["lib"]],
+  overwrite = TRUE
+))
 
 test_that("--help snapshots", {
   expect_snapshot(write_cli_output("flip-coin", "--help"))

--- a/tests/testthat/test-help-snapshots.R
+++ b/tests/testthat/test-help-snapshots.R
@@ -59,6 +59,10 @@ profile_lines <- c(
 writeLines(profile_lines, pkg_profile)
 withr::defer(unlink(pkg_profile), envir = snapshot_env)
 withr::local_envvar(R_PROFILE_USER = pkg_profile, .local_envir = snapshot_env)
+withr::local_envvar(
+  c("RAPP_NO_MODIFY_PATH" = "1"),
+  .local_envir = snapshot_env
+)
 
 destdir <- tempfile("rapp-help-bin")
 dir.create(destdir, recursive = TRUE, showWarnings = FALSE)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,4 +1,6 @@
 test_that("install_pkg_cli_apps installs launchers for matching scripts", {
+  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
+  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
   pkg <- "rappTestBasic"
   fake <- setup_fake_rapp_package(tempdir(), "-install-basic", package = pkg)
   on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
@@ -23,7 +25,6 @@ test_that("install_pkg_cli_apps installs launchers for matching scripts", {
 
   destdir <- tempfile("rapp-bin-basic")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
-  withr::local_path(destdir)
 
   expect_false(dir.exists(destdir))
 
@@ -78,6 +79,9 @@ test_that("install_pkg_cli_apps installs launchers for matching scripts", {
 
 
 test_that("install_pkg_cli_apps installs launchers for conventional Rscript apps", {
+  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
+  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
+
   pkg <- "rappTestRscript"
   fake <- setup_fake_rapp_package(tempdir(), "-install-rscript", package = pkg)
   on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
@@ -93,7 +97,6 @@ test_that("install_pkg_cli_apps installs launchers for conventional Rscript apps
 
   destdir <- tempfile("rapp-bin-rscript")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
-  withr::local_path(destdir)
 
   messages <- character()
   created <- withCallingHandlers(
@@ -143,6 +146,9 @@ test_that("install_pkg_cli_apps installs launchers for conventional Rscript apps
 
 
 test_that("non-Rapp executables respect overwrite flag", {
+  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
+  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
+
   pkg <- "rappTestOverwrite"
   fake <- setup_fake_rapp_package(
     tempdir(),
@@ -157,7 +163,6 @@ test_that("non-Rapp executables respect overwrite flag", {
   destdir <- tempfile("rapp-bin-overwrite")
   dir.create(destdir, recursive = TRUE)
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
-  withr::local_path(destdir)
 
   target <- if (is_windows()) {
     path(destdir, "clash.bat")
@@ -209,6 +214,9 @@ test_that("non-Rapp executables respect overwrite flag", {
 
 
 test_that("front matter customises launcher options", {
+  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
+  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
+
   pkg <- "rappTestFront"
   fake <- setup_fake_rapp_package(
     tempdir(),
@@ -237,7 +245,6 @@ test_that("front matter customises launcher options", {
 
   destdir <- tempfile("rapp-bin-frontmatter")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
-  withr::local_path(destdir)
 
   messages <- character()
   created <- withCallingHandlers(
@@ -271,42 +278,9 @@ test_that("front matter customises launcher options", {
 })
 
 
-test_that("process PATH entry prevents Windows registry modification", {
-  pkg <- "rappTestPathEntry"
-  fake <- setup_fake_rapp_package(
-    tempdir(),
-    "-install-path-entry",
-    package = pkg
-  )
-  on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
-
-  app_path <- file.path(fake[["exec"]], "path-entry.R")
-  writeLines(c("#!/usr/bin/env Rapp", "print('path entry')"), app_path)
-
-  destdir <- tempfile("rapp-bin-path-entry")
-  dir.create(destdir, recursive = TRUE)
-  on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
-  withr::local_path(destdir, action = "replace")
-
-  testthat::local_mocked_bindings(
-    is_windows = function() TRUE,
-    get_env_win_registry = function(name) {
-      stop("unexpected registry access", call. = FALSE)
-    },
-    .package = "Rapp"
-  )
-
-  expect_no_error(
-    suppressMessages(install_pkg_cli_apps(
-      pkg,
-      destdir = destdir,
-      lib.loc = fake[["lib"]]
-    ))
-  )
-})
-
-
 test_that("install_pkg_cli_apps prunes orphaned launchers", {
+  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
+  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
   pkg <- "rappTestPrune"
   fake <- setup_fake_rapp_package(tempdir(), "-install-prune", package = pkg)
   on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
@@ -318,7 +292,6 @@ test_that("install_pkg_cli_apps prunes orphaned launchers", {
 
   destdir <- tempfile("rapp-bin-prune")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
-  withr::local_path(destdir)
 
   messages <- character()
   first_created <- withCallingHandlers(

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,6 +1,4 @@
 test_that("install_pkg_cli_apps installs launchers for matching scripts", {
-  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
-  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
   pkg <- "rappTestBasic"
   fake <- setup_fake_rapp_package(tempdir(), "-install-basic", package = pkg)
   on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
@@ -25,6 +23,7 @@ test_that("install_pkg_cli_apps installs launchers for matching scripts", {
 
   destdir <- tempfile("rapp-bin-basic")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+  withr::local_path(destdir)
 
   expect_false(dir.exists(destdir))
 
@@ -79,9 +78,6 @@ test_that("install_pkg_cli_apps installs launchers for matching scripts", {
 
 
 test_that("install_pkg_cli_apps installs launchers for conventional Rscript apps", {
-  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
-  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
-
   pkg <- "rappTestRscript"
   fake <- setup_fake_rapp_package(tempdir(), "-install-rscript", package = pkg)
   on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
@@ -97,6 +93,7 @@ test_that("install_pkg_cli_apps installs launchers for conventional Rscript apps
 
   destdir <- tempfile("rapp-bin-rscript")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+  withr::local_path(destdir)
 
   messages <- character()
   created <- withCallingHandlers(
@@ -146,9 +143,6 @@ test_that("install_pkg_cli_apps installs launchers for conventional Rscript apps
 
 
 test_that("non-Rapp executables respect overwrite flag", {
-  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
-  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
-
   pkg <- "rappTestOverwrite"
   fake <- setup_fake_rapp_package(
     tempdir(),
@@ -163,6 +157,7 @@ test_that("non-Rapp executables respect overwrite flag", {
   destdir <- tempfile("rapp-bin-overwrite")
   dir.create(destdir, recursive = TRUE)
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+  withr::local_path(destdir)
 
   target <- if (is_windows()) {
     path(destdir, "clash.bat")
@@ -242,6 +237,7 @@ test_that("front matter customises launcher options", {
 
   destdir <- tempfile("rapp-bin-frontmatter")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+  withr::local_path(destdir)
 
   messages <- character()
   created <- withCallingHandlers(
@@ -275,9 +271,42 @@ test_that("front matter customises launcher options", {
 })
 
 
+test_that("process PATH entry prevents Windows registry modification", {
+  pkg <- "rappTestPathEntry"
+  fake <- setup_fake_rapp_package(
+    tempdir(),
+    "-install-path-entry",
+    package = pkg
+  )
+  on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
+
+  app_path <- file.path(fake[["exec"]], "path-entry.R")
+  writeLines(c("#!/usr/bin/env Rapp", "print('path entry')"), app_path)
+
+  destdir <- tempfile("rapp-bin-path-entry")
+  dir.create(destdir, recursive = TRUE)
+  on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+  withr::local_path(destdir, action = "replace")
+
+  testthat::local_mocked_bindings(
+    is_windows = function() TRUE,
+    get_env_win_registry = function(name) {
+      stop("unexpected registry access", call. = FALSE)
+    },
+    .package = "Rapp"
+  )
+
+  expect_no_error(
+    suppressMessages(install_pkg_cli_apps(
+      pkg,
+      destdir = destdir,
+      lib.loc = fake[["lib"]]
+    ))
+  )
+})
+
+
 test_that("install_pkg_cli_apps prunes orphaned launchers", {
-  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
-  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
   pkg <- "rappTestPrune"
   fake <- setup_fake_rapp_package(tempdir(), "-install-prune", package = pkg)
   on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
@@ -289,6 +318,7 @@ test_that("install_pkg_cli_apps prunes orphaned launchers", {
 
   destdir <- tempfile("rapp-bin-prune")
   on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+  withr::local_path(destdir)
 
   messages <- character()
   first_created <- withCallingHandlers(

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -214,8 +214,7 @@ test_that("non-Rapp executables respect overwrite flag", {
 
 
 test_that("front matter customises launcher options", {
-  Sys.setenv("RAPP_NO_MODIFY_PATH" = "1")
-  on.exit(Sys.unsetenv("RAPP_NO_MODIFY_PATH"), add = TRUE)
+  withr::local_envvar(RAPP_NO_MODIFY_PATH = "1")
 
   pkg <- "rappTestFront"
   fake <- setup_fake_rapp_package(


### PR DESCRIPTION
Fixes tests that installed Rapp launchers into temporary directories without disabling Windows PATH modification. On CRAN Windows, that could leave dead temp paths in the user PATH registry.

User-facing changes: none.

Internal changes: tests now keep launcher install setup from mutating persistent Windows user PATH state.
