### PR TITLE
Fix R 3.6 install parse error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 ## Bug fixes
 
 -   Running tests no longer modifies the user `PATH` on Windows (#26).
+-   Rapp now installs from source on R versions before 4.0.0 by avoiding
+    raw string literal syntax (#30).
 
 # Rapp 0.3.0
 

--- a/R/install.R
+++ b/R/install.R
@@ -405,7 +405,7 @@ install_rapp_launcher <- function(destdir, overwrite = NA) {
       paste("::", sentinel),
       "setlocal",
       sprintf(
-        r"("%s/Rscript.exe" -e Rapp::run() %%*)",
+        '"%s/Rscript.exe" -e Rapp::run() %%*',
         R.home("bin")
       )
     ),
@@ -413,7 +413,7 @@ install_rapp_launcher <- function(destdir, overwrite = NA) {
       "#!/bin/sh",
       paste("#", sentinel),
       sprintf(
-        r"(exec %s/Rscript -e 'Rapp::run()' "$@")",
+        'exec %s/Rscript -e "Rapp::run()" "$@"',
         R.home("bin")
       )
     )


### PR DESCRIPTION
## Summary

Fixes r-lib/Rapp#25 by replacing R 4 raw string literals in `install_rapp_launcher()` with ordinary string constants. This lets the package source parse during installation on older R versions such as R 3.6.

## User-facing changes

- Source installs no longer fail on older R versions that do not support raw string literals.

## Internal changes

- Keeps the generated Windows and Unix Rapp launcher commands equivalent while using R 3.6-compatible syntax.
- Does not add tests; full coverage for this issue belongs in an older-R CI matrix job.
