### PR TITLE
Reject typed CLI values that do not match parsed YAML types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,9 +7,9 @@
     bool options still accept YAML 1.1 bool aliases such as `yes`, `no`,
     `y`, `n`, `on`, and `off` for backward compatibility.
 -   Rapp now checks parsed command line values against declared option
-    types instead of coercing them. For example, integer options no
-    longer accept float or logical values such as `10.2` or `true`
-    (#18).
+    types instead of coercing them. Integer options no longer accept
+    float or logical values such as `10.2` or `true`; float options still
+    accept integer values (#18).
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,10 @@
     non-bool option values are strings, not boolean aliases. Declared
     bool options still accept YAML 1.1 bool aliases such as `yes`, `no`,
     `y`, `n`, `on`, and `off` for backward compatibility.
--   Rapp now rejects lossy command line coercions for typed options. For
-    example, integer options no longer accept float or logical values
-    such as `10.2` or `true` (#18).
+-   Rapp now checks parsed command line values against declared option
+    types instead of coercing them. For example, integer options no
+    longer accept float or logical values such as `10.2` or `true`
+    (#18).
 
 ## New features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
     non-bool option values are strings, not boolean aliases. Declared
     bool options still accept YAML 1.1 bool aliases such as `yes`, `no`,
     `y`, `n`, `on`, and `off` for backward compatibility.
+-   Rapp now rejects lossy command line coercions for typed options. For
+    example, integer options no longer accept float or logical values
+    such as `10.2` or `true` (#18).
 
 ## New features
 

--- a/R/args.R
+++ b/R/args.R
@@ -133,7 +133,23 @@ process_args <- function(args, app) {
     }
     if (mode != "character") {
       received_val <- val
-      val <- parse_yaml(val)
+      val <- if (mode == "any") {
+        tryCatch(parse_yaml(val), error = function(e) received_val)
+      } else {
+        parse_yaml(val)
+      }
+      if (mode == "double" && identical(typeof(val), "integer")) {
+        val <- as.vector(val, mode)
+      }
+      if (mode != "any" && is.list(val)) {
+        types <- vapply(val, typeof, character(1))
+        if (
+          all(types == mode) ||
+            mode == "double" && all(types %in% c("integer", "double"))
+        ) {
+          val <- as.vector(val, mode)
+        }
+      }
       if (mode != "any" && !identical(typeof(val), mode)) {
         stop(
           sprintf(

--- a/R/args.R
+++ b/R/args.R
@@ -127,6 +127,11 @@ process_args <- function(args, app) {
     if (identical(spec$val_type, "bool")) {
       val <- normalize_bool_cli_value(val)
     }
+
+    # TODO: do we care about enforcing or formalizing flag val length?
+    # right now, a val like [1,2,3] gets parsed and is injected as a
+    # length 3 integer vector.
+    # Decide if this needs a guardrail or paving and signage.
     if (mode != "character") {
       received_val <- val
       val <- parse_yaml(val)

--- a/R/args.R
+++ b/R/args.R
@@ -115,10 +115,6 @@ process_args <- function(args, app) {
       }
     }
 
-    # TODO: do we care about enforcing or formalizing flag val length?
-    # right now, a val like [1,2,3] gets parsed and is injected as a
-    # length 3 integer vector.
-    # Decide if this needs a guardrail or paving and signage.
     val <- parse_cli_option_value(val, spec, name)
 
     # val can be NULL
@@ -233,12 +229,15 @@ normalize_bool_cli_value <- function(val) {
 
 parse_cli_option_value <- function(val, spec, name) {
   stopifnot(is.character(val), length(val) == 1L)
-  stopifnot(is.list(spec), is.character(name), length(name) == 1L)
-  stopifnot(is.character(spec$val_type), length(spec$val_type) == 1L)
+  stopifnot(is.list(spec), is.character(spec$val_type))
+  stopifnot(is.character(name), length(name) == 1L)
+  stopifnot(length(spec$val_type) == 1L)
 
   if (identical(spec$val_type, "string")) {
     return(val)
   }
+
+  received_val <- val
 
   if (identical(spec$val_type, "bool")) {
     val <- normalize_bool_cli_value(val)
@@ -250,61 +249,37 @@ parse_cli_option_value <- function(val, spec, name) {
     return(val)
   }
 
-  if (!cli_value_matches_type(val, spec$val_type)) {
-    stop(
-      sprintf(
-        "Invalid value for --%s: expected %s.",
-        to_kebab_case(name),
-        spec$val_type
-      ),
-      call. = FALSE
-    )
-  }
-
-  mode <- switch(
+  expected_type <- switch(
     spec$val_type,
     "bool" = "logical",
     "float" = "double",
     "integer" = "integer"
   )
-  as.vector(val, mode)
+  if (!identical(typeof(val), expected_type)) {
+    stop(
+      sprintf(
+        "Invalid value for --%s: expected %s, but parsed %s as %s.",
+        to_kebab_case(name),
+        spec$val_type,
+        encodeString(received_val, quote = '"'),
+        cli_value_type(val)
+      ),
+      call. = FALSE
+    )
+  }
+  val
 }
 
-cli_value_matches_type <- function(val, val_type) {
-  types <- cli_value_leaf_types(val)
-  if (!length(types)) {
-    return(FALSE)
-  }
-
+cli_value_type <- function(val) {
   switch(
-    val_type,
-    "bool" = all(types == "logical"),
-    "float" = all(types %in% c("integer", "double")),
-    "integer" = {
-      if (!all(types %in% c("integer", "double"))) {
-        return(FALSE)
-      }
-      val <- as.vector(val, "double")
-      all(
-        is.finite(val) &
-          val >= (-.Machine$integer.max - 1) &
-          val <= .Machine$integer.max &
-          val == trunc(val)
-      )
-    },
-    "string" = all(types == "character"),
-    "any" = TRUE,
-    FALSE
+    typeof(val),
+    "character" = "string",
+    "logical" = "bool",
+    "double" = "float",
+    "integer" = "integer",
+    "list" = "YAML collection",
+    typeof(val)
   )
-}
-
-cli_value_leaf_types <- function(x) {
-  if (!is.list(x)) {
-    return(typeof(x))
-  }
-
-  out <- unlist(lapply(x, cli_value_leaf_types), use.names = FALSE)
-  if (is.null(out)) character() else out
 }
 
 to_snake_case <- function(x) gsub("-", "_", x, fixed = TRUE)

--- a/R/args.R
+++ b/R/args.R
@@ -115,7 +115,33 @@ process_args <- function(args, app) {
       }
     }
 
-    val <- parse_cli_option_value(val, spec, name)
+    mode <- switch(
+      spec$val_type,
+      "string" = "character",
+      "bool" = "logical",
+      "float" = "double",
+      "integer" = "integer",
+      "any"
+    )
+
+    if (identical(spec$val_type, "bool")) {
+      val <- normalize_bool_cli_value(val)
+    }
+    if (mode != "character") {
+      received_val <- val
+      val <- parse_yaml(val)
+      if (mode != "any" && !identical(typeof(val), mode)) {
+        stop(
+          sprintf(
+            "Invalid value for --%s: expected %s, received %s.",
+            to_kebab_case(name),
+            spec$val_type,
+            encodeString(received_val, quote = '"')
+          ),
+          call. = FALSE
+        )
+      }
+    }
 
     # val can be NULL
     if (identical(spec$action, "append")) {
@@ -224,61 +250,6 @@ normalize_bool_cli_value <- function(val) {
     "off" = , "Off" = , "OFF" = ,
     "0" = "false",
     val
-  )
-}
-
-parse_cli_option_value <- function(val, spec, name) {
-  stopifnot(is.character(val), length(val) == 1L)
-  stopifnot(is.list(spec), is.character(spec$val_type))
-  stopifnot(is.character(name), length(name) == 1L)
-  stopifnot(length(spec$val_type) == 1L)
-
-  if (identical(spec$val_type, "string")) {
-    return(val)
-  }
-
-  received_val <- val
-
-  if (identical(spec$val_type, "bool")) {
-    val <- normalize_bool_cli_value(val)
-  }
-
-  val <- parse_yaml(val)
-
-  if (identical(spec$val_type, "any")) {
-    return(val)
-  }
-
-  expected_type <- switch(
-    spec$val_type,
-    "bool" = "logical",
-    "float" = "double",
-    "integer" = "integer"
-  )
-  if (!identical(typeof(val), expected_type)) {
-    stop(
-      sprintf(
-        "Invalid value for --%s: expected %s, but parsed %s as %s.",
-        to_kebab_case(name),
-        spec$val_type,
-        encodeString(received_val, quote = '"'),
-        cli_value_type(val)
-      ),
-      call. = FALSE
-    )
-  }
-  val
-}
-
-cli_value_type <- function(val) {
-  switch(
-    typeof(val),
-    "character" = "string",
-    "logical" = "bool",
-    "double" = "float",
-    "integer" = "integer",
-    "list" = "YAML collection",
-    typeof(val)
   )
 }
 

--- a/R/args.R
+++ b/R/args.R
@@ -136,19 +136,10 @@ process_args <- function(args, app) {
       val <- if (mode == "any") {
         tryCatch(parse_yaml(val), error = function(e) received_val)
       } else {
-        parse_yaml(val)
+        parse_yaml(val, simplify = TRUE)
       }
       if (mode == "double" && identical(typeof(val), "integer")) {
         val <- as.vector(val, mode)
-      }
-      if (mode != "any" && is.list(val)) {
-        types <- vapply(val, typeof, character(1))
-        if (
-          all(types == mode) ||
-            mode == "double" && all(types %in% c("integer", "double"))
-        ) {
-          val <- as.vector(val, mode)
-        }
       }
       if (mode != "any" && !identical(typeof(val), mode)) {
         stop(

--- a/R/args.R
+++ b/R/args.R
@@ -124,14 +124,13 @@ process_args <- function(args, app) {
       "any"
     )
 
-    if (identical(spec$val_type, "bool")) {
-      val <- normalize_bool_cli_value(val)
-    }
-
     # TODO: do we care about enforcing or formalizing flag val length?
     # right now, a val like [1,2,3] gets parsed and is injected as a
     # length 3 integer vector.
     # Decide if this needs a guardrail or paving and signage.
+    if (identical(spec$val_type, "bool")) {
+      val <- normalize_bool_cli_value(val)
+    }
     if (mode != "character") {
       received_val <- val
       val <- parse_yaml(val)

--- a/R/args.R
+++ b/R/args.R
@@ -115,41 +115,11 @@ process_args <- function(args, app) {
       }
     }
 
-    mode <- switch(
-      spec$val_type,
-      "string" = "character",
-      "bool" = "logical",
-      "float" = "double",
-      "integer" = "integer",
-      "any"
-    )
-
     # TODO: do we care about enforcing or formalizing flag val length?
     # right now, a val like [1,2,3] gets parsed and is injected as a
     # length 3 integer vector.
     # Decide if this needs a guardrail or paving and signage.
-
-    # Try coerce to the R type, but if coercion fails, e.g.:
-    # Warning in as.vector("1a", "integer") : NAs introduced by coercion
-    # Then keep the original yaml parsed val as is.
-    # NAs cannot be injected from cli args via regular yaml,
-    # NAs are sentinals users can use to check if an opt was supplied.
-    # (but anything is possible with '!expr ...')
-    if (identical(spec$val_type, "bool")) {
-      val <- normalize_bool_cli_value(val)
-    }
-    if (mode != "character") {
-      tryCatch(
-        {
-          val <- parse_yaml(val)
-          if (!is.na(coerced_val <- as.vector(val, mode))) {
-            val <- coerced_val
-          }
-        },
-        error = identity,
-        warning = identity
-      )
-    }
+    val <- parse_cli_option_value(val, spec, name)
 
     # val can be NULL
     if (identical(spec$action, "append")) {
@@ -259,6 +229,82 @@ normalize_bool_cli_value <- function(val) {
     "0" = "false",
     val
   )
+}
+
+parse_cli_option_value <- function(val, spec, name) {
+  stopifnot(is.character(val), length(val) == 1L)
+  stopifnot(is.list(spec), is.character(name), length(name) == 1L)
+  stopifnot(is.character(spec$val_type), length(spec$val_type) == 1L)
+
+  if (identical(spec$val_type, "string")) {
+    return(val)
+  }
+
+  if (identical(spec$val_type, "bool")) {
+    val <- normalize_bool_cli_value(val)
+  }
+
+  val <- parse_yaml(val)
+
+  if (identical(spec$val_type, "any")) {
+    return(val)
+  }
+
+  if (!cli_value_matches_type(val, spec$val_type)) {
+    stop(
+      sprintf(
+        "Invalid value for --%s: expected %s.",
+        to_kebab_case(name),
+        spec$val_type
+      ),
+      call. = FALSE
+    )
+  }
+
+  mode <- switch(
+    spec$val_type,
+    "bool" = "logical",
+    "float" = "double",
+    "integer" = "integer"
+  )
+  as.vector(val, mode)
+}
+
+cli_value_matches_type <- function(val, val_type) {
+  types <- cli_value_leaf_types(val)
+  if (!length(types)) {
+    return(FALSE)
+  }
+
+  switch(
+    val_type,
+    "bool" = all(types == "logical"),
+    "float" = all(types %in% c("integer", "double")),
+    "integer" = {
+      if (!all(types %in% c("integer", "double"))) {
+        return(FALSE)
+      }
+      val <- as.vector(val, "double")
+      all(
+        is.finite(val) &
+          val >= (-.Machine$integer.max - 1) &
+          val <= .Machine$integer.max &
+          val == trunc(val)
+      )
+    },
+    "string" = all(types == "character"),
+    "any" = TRUE,
+    FALSE
+  )
+}
+
+cli_value_leaf_types <- function(x) {
+  if (!is.list(x)) {
+    return(typeof(x))
+  }
+
+  out <- unlist(lapply(x, cli_value_leaf_types), use.names = FALSE)
+  if (is.null(out)) character() else out
 }
 
 to_snake_case <- function(x) gsub("-", "_", x, fixed = TRUE)

--- a/README.md
+++ b/README.md
@@ -99,11 +99,10 @@ flip-coin --n 1
 ```
 
 Non-string option values passed from the command line are parsed as
-YAML/JSON and must match the original R type. Numeric values are
-normalized without lossy coercion, so a float can accept an integer value
-but an integer option rejects values like `10.2` or `true`. Values can be
-supplied after the option flag, or as part of the option flag string with
-`=`. The following two usages are the same:
+YAML/JSON and must match the original R type. For example, an integer
+option rejects values like `10.2` or `true`. Values can be supplied after
+the option flag, or as part of the option flag string with `=`. The
+following two usages are the same:
 
 ``` bash
 flip-coin --n=1

--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ flip-coin --n 1
 ```
 
 Non-string option values passed from the command line are parsed as
-YAML/JSON, and then coerced to the original R type. Values can be
-supplied after the option flag, or as part of the option flag string
-with `=`. The following two usages are the same:
+YAML/JSON and must match the original R type. Numeric values are
+normalized without lossy coercion, so a float can accept an integer value
+but an integer option rejects values like `10.2` or `true`. Values can be
+supplied after the option flag, or as part of the option flag string with
+`=`. The following two usages are the same:
 
 ``` bash
 flip-coin --n=1

--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ flip-coin --n 1
 
 Non-string option values passed from the command line are parsed as
 YAML/JSON and must match the original R type. For example, an integer
-option rejects values like `10.2` or `true`. Values can be supplied after
-the option flag, or as part of the option flag string with `=`. The
-following two usages are the same:
+option rejects values like `10.2` or `true`, while float options accept
+integer or float YAML values. Values can be supplied after the option
+flag, or as part of the option flag string with `=`. The following two
+usages are the same:
 
 ``` bash
 flip-coin --n=1

--- a/tests/testthat/_snaps/regressions.md
+++ b/tests/testthat/_snaps/regressions.md
@@ -4,7 +4,7 @@
       Rapp::run(app_path, c("--flips", "10.2"))
     Condition
       Error:
-      ! Invalid value for --flips: expected integer, but parsed "10.2" as float.
+      ! Invalid value for --flips: expected integer, received "10.2".
 
 ---
 
@@ -12,5 +12,5 @@
       Rapp::run(app_path, c("--flips", "TRUE"))
     Condition
       Error:
-      ! Invalid value for --flips: expected integer, but parsed "TRUE" as bool.
+      ! Invalid value for --flips: expected integer, received "TRUE".
 

--- a/tests/testthat/_snaps/regressions.md
+++ b/tests/testthat/_snaps/regressions.md
@@ -1,0 +1,16 @@
+# integer options require YAML integer values
+
+    Code
+      Rapp::run(app_path, c("--flips", "10.2"))
+    Condition
+      Error:
+      ! Invalid value for --flips: expected integer, but parsed "10.2" as float.
+
+---
+
+    Code
+      Rapp::run(app_path, c("--flips", "TRUE"))
+    Condition
+      Error:
+      ! Invalid value for --flips: expected integer, but parsed "TRUE" as bool.
+

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -161,6 +161,28 @@ test_that("YAML 1.1 bool aliases stay strings for parsed non-bool options", {
   expect_identical(env$value, list("on", "off", "y", "n"))
 })
 
+test_that("integer options reject lossy CLI coercions", {
+  app_path <- local_rapp_app(
+    c(
+      "#!/usr/bin/env Rapp",
+      "flips <- 1L"
+    ),
+    prefix = "rapp-lossy-integer-"
+  )
+
+  env <- Rapp::run(app_path, c("--flips", "2"))
+  expect_identical(env$flips, 2L)
+
+  expect_error(
+    Rapp::run(app_path, c("--flips", "10.2")),
+    "expected integer"
+  )
+  expect_error(
+    Rapp::run(app_path, c("--flips", "TRUE")),
+    "expected integer"
+  )
+})
+
 test_that("YAML help records typed NA defaults as null", {
   app_path <- local_rapp_app(
     c(

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -161,6 +161,22 @@ test_that("YAML 1.1 bool aliases stay strings for parsed non-bool options", {
   expect_identical(env$value, list("on", "off", "y", "n"))
 })
 
+test_that("any options keep raw strings when YAML parsing fails", {
+  app_path <- local_rapp_app(
+    c(
+      "#!/usr/bin/env Rapp",
+      "value <- list()"
+    ),
+    prefix = "rapp-any-invalid-yaml-"
+  )
+
+  env <- Rapp::run(
+    app_path,
+    c("--value", "[not closed", "--value", "{ok: true}")
+  )
+  expect_identical(env$value, list("[not closed", list(ok = TRUE)))
+})
+
 test_that("integer options require YAML integer values", {
   app_path <- local_rapp_app(
     c(
@@ -175,6 +191,40 @@ test_that("integer options require YAML integer values", {
 
   expect_snapshot(error = TRUE, Rapp::run(app_path, c("--flips", "10.2")))
   expect_snapshot(error = TRUE, Rapp::run(app_path, c("--flips", "TRUE")))
+})
+
+test_that("float options accept YAML integer values", {
+  app_path <- local_rapp_app(
+    c(
+      "#!/usr/bin/env Rapp",
+      "rate <- 0.25"
+    ),
+    prefix = "rapp-float-integer-"
+  )
+
+  env <- Rapp::run(app_path, c("--rate", "1"))
+  expect_identical(env$rate, 1)
+})
+
+test_that("typed options accept YAML sequences with matching values", {
+  app_path <- local_rapp_app(
+    c(
+      "#!/usr/bin/env Rapp",
+      "flips <- 1L",
+      "rate <- 0.25",
+      "flags <- FALSE"
+    ),
+    prefix = "rapp-typed-sequence-"
+  )
+
+  env <- Rapp::run(app_path, c("--flips", "[1, 2]"))
+  expect_identical(env$flips, c(1L, 2L))
+
+  env <- Rapp::run(app_path, c("--rate", "[1, 2.5]"))
+  expect_identical(env$rate, c(1, 2.5))
+
+  env <- Rapp::run(app_path, "--flags=[true, false]")
+  expect_identical(env$flags, c(TRUE, FALSE))
 })
 
 test_that("YAML help records typed NA defaults as null", {

--- a/tests/testthat/test-regressions.R
+++ b/tests/testthat/test-regressions.R
@@ -161,7 +161,7 @@ test_that("YAML 1.1 bool aliases stay strings for parsed non-bool options", {
   expect_identical(env$value, list("on", "off", "y", "n"))
 })
 
-test_that("integer options reject lossy CLI coercions", {
+test_that("integer options require YAML integer values", {
   app_path <- local_rapp_app(
     c(
       "#!/usr/bin/env Rapp",
@@ -173,14 +173,8 @@ test_that("integer options reject lossy CLI coercions", {
   env <- Rapp::run(app_path, c("--flips", "2"))
   expect_identical(env$flips, 2L)
 
-  expect_error(
-    Rapp::run(app_path, c("--flips", "10.2")),
-    "expected integer"
-  )
-  expect_error(
-    Rapp::run(app_path, c("--flips", "TRUE")),
-    "expected integer"
-  )
+  expect_snapshot(error = TRUE, Rapp::run(app_path, c("--flips", "10.2")))
+  expect_snapshot(error = TRUE, Rapp::run(app_path, c("--flips", "TRUE")))
 })
 
 test_that("YAML help records typed NA defaults as null", {


### PR DESCRIPTION
**Summary**
- Change CLI option handling so non-string values are parsed as YAML and then validated against the declared option type instead of being coerced.
- This makes invalid inputs fail fast with a user-facing error that names the option, the expected type, and the received CLI value.
- Updates the README and NEWS entry to reflect the stricter type behavior.

Closes #18.

**User-facing changes**
- Integer options now reject values like `10.2` and `TRUE` instead of silently accepting them.
- Error messages now describe the option name, the expected type, and the received CLI value.
- README language now says typed options must match the declared R type.

**Internal changes**
- Replaced the old coercion path in `R/args.R` with a YAML-parse-and-validate flow.
- Added regression coverage for the stricter typed parsing behavior and new error messages.
- Removed the lossy coercion logic that depended on `as.vector()` fallback behavior.
