### PR TITLE
Clarify package launcher installation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 
 ## Bug fixes
 
+-   Launcher front matter now accepts documented kebab-case option names
+    such as `default-packages`. Installation docs now clarify that package
+    apps are discovered as `exec/*.R`, installed without the `.R` extension
+    by default, and installed to `RAPP_BIN_DIR` when set (#19, #20).
 -   Running tests no longer modifies the user `PATH` on Windows (#26).
 -   Rapp now installs from source on R versions before 4.0.0 by avoiding
     raw string literal syntax (#30).

--- a/R/app.R
+++ b/R/app.R
@@ -57,6 +57,10 @@ get_app_data <- function(app) {
     structure(list(), names = character())
   }
 
+  if (!is.null(data[["launcher"]])) {
+    data[["launcher"]] <- normalize_anno_keys(data[["launcher"]])
+  }
+
   data
 }
 

--- a/R/install.R
+++ b/R/install.R
@@ -5,12 +5,15 @@
 #' Rapp`) or `Rscript` (for example, `#!/usr/bin/env Rscript`). Each discovered
 #' script gets a lightweight launcher in `destdir` that invokes `Rapp` or
 #' `Rscript` to run the app. The launcher encodes the absolute path to the R
-#' binary this function is called from.
+#' binary this function is called from, and its name defaults to the script
+#' basename without the `.R` extension.
 #'
-#' Optional `#| launcher:` front matter in the script lets authors tune the
-#' `Rscript` flags. By default, for both `Rscript` and `Rapp`, R is invoked with
-#' `--default-packages=base,<pkg>`, where `<pkg>` is the package providing the
-#' executable.
+#' Optional `#| launcher:` front matter in the script lets authors set the
+#' installed launcher `name` and tune the `Rscript` flags. By default, package
+#' apps are invoked with `--default-packages=base,<pkg>`, where `<pkg>` is the
+#' package providing the executable. The top-level `Rapp` launcher installed by
+#' `install_pkg_cli_apps("Rapp")` invokes `Rscript -e Rapp::run()` without
+#' package app defaults.
 #'
 #' @param package Package names to process. Defaults to the calling package when
 #'   run inside a package; otherwise all installed packages.
@@ -27,10 +30,10 @@
 #' @details
 #'
 #' Launchers are regenerated each time `install_pkg_cli_apps()` is called, and
-#' any obsolete launchers for the same package are removed. `RAPP_INSTALL_DIR`
+#' any obsolete launchers for the same package are removed. `RAPP_BIN_DIR`
 #' overrides the default destination. Launchers are POSIX shell scripts on
 #' Unix-like systems and `.bat` files on Windows. Front-matter options such as
-#' `vanilla`, `no-environ`, and `default_packages` map directly to the
+#' `name`, `vanilla`, `no-environ`, and `default-packages` map directly to the
 #' corresponding `Rscript` arguments.
 #'
 #' When `overwrite` is `NA`, files previously written by Rapp are always
@@ -39,7 +42,7 @@
 #' executable.
 #'
 #' If `destdir` is not provided, it is resolved in this order:
-#'   - env var `RAPP_INSTALL_DIR`
+#'   - env var `RAPP_BIN_DIR`
 #'   - env var `XDG_BIN_HOME`
 #'   - env var `XDG_DATA_HOME/../bin`
 #'   - the default location:
@@ -61,6 +64,7 @@
 #' #!/usr/bin/env Rapp
 #' #| description: About this app
 #' #| launcher:
+#' #|   name: about
 #' #|   vanilla: true
 #' #|   default-packages: [base, utils, mypkg]
 #' ```
@@ -278,9 +282,9 @@ launcher_contents <- function(app_path, package) {
   # assemble rscript opts
   rscript_opts <- c(
     if (isTRUE(rscript_opts[["vanilla"]])) "--vanilla",
-    if (isTRUE(rscript_opts[["no-environ"]])) "--no-environ",
-    if (isTRUE(rscript_opts[["no-site-file"]])) "--no-site-file",
-    if (isTRUE(rscript_opts[["no-init-file"]])) "--no-init-file",
+    if (isTRUE(rscript_opts[["no_environ"]])) "--no-environ",
+    if (isTRUE(rscript_opts[["no_site_file"]])) "--no-site-file",
+    if (isTRUE(rscript_opts[["no_init_file"]])) "--no-init-file",
     if (isTRUE(rscript_opts[["restore"]])) "--restore",
     if (isTRUE(rscript_opts[["save"]])) "--save",
     if (isTRUE(rscript_opts[["verbose"]])) "--verbose",

--- a/README.md
+++ b/README.md
@@ -400,8 +400,9 @@ prefer, call the front end explicitly with `Rapp flip-coin.R --n 3`.
 
 If you are shipping Rapps via an R package, you can call
 `Rapp::install_pkg_cli_apps("mypackage")` to install lightweight
-launchers for every Rapp (and Rscript shebang) in the package's `exec/`
-directory.
+launchers for every `.R` script in the package's `exec/` directory whose
+shebang line invokes `Rapp` or `Rscript`. A script named `exec/myapp.R`
+is installed as the command `myapp` by default.
 
 ``` r
 Rapp::install_pkg_cli_apps("mypackage")
@@ -421,23 +422,39 @@ install_mypackage_cli <- function(...) {
 ```
 
 App launchers are written to `destdir`, which defaults to the first
-available location from `RAPP_INSTALL_DIR`, `XDG_BIN_HOME`,
+available location from `RAPP_BIN_DIR`, `XDG_BIN_HOME`,
 `XDG_DATA_HOME/../bin`, or the default location, `~/.local/bin` on macOS
 and Linux and `%LOCALAPPDATA%\Programs\R\Rapp\bin` on Windows. On
 Windows the directory is automatically added to `PATH`; on macOS and
 Linux the directory generally is already present on `PATH` (you may need
 to restart your shell if the Rapp installer created the directory). Use
-the `destdir` argument if you prefer an alternate location. If you are
-working with a standalone `.R` file on Windows, call the launcher
-explicitly (`Rapp path\to\flip-coin.R --n 3`) because native shebangs
-are not supported.
+the `destdir` argument if you prefer an alternate location.
+
+Use `#| launcher:` front matter to customize the installed launcher. For
+example, `name` changes the installed command name, and `vanilla`,
+`no-environ`, and `default-packages` tune the generated `Rscript`
+invocation.
+
+``` r
+#!/usr/bin/env Rapp
+#| launcher:
+#|   name: myapp-fast
+#|   vanilla: true
+#|   default-packages: [base, utils, mypackage]
+```
+
+If you are working with a standalone `.R` file on Windows, call the
+launcher explicitly (`Rapp path\to\flip-coin.R --n 3`) because native
+shebangs are not supported.
 
 ### Using package `exec/` directories directly
 
 Launchers are optional. You can add `Rapp` and a package's `exec/`
 directory to the `PATH` and run the apps directly from the package's
-installed directory. For example, after installing {Rapp}, you can place
-something like this in a shell startup script like `.bashrc`:
+installed directory. Direct execution uses the script filename, such as
+`myapp.R`; extensionless command names come from generated launchers. For
+example, after installing {Rapp}, you can place something like this in a
+shell startup script like `.bashrc`:
 
 ``` bash
 export PATH="$(Rscript -e 'cat(normalizePath(system.file("exec", package = "Rapp")))'):$PATH"
@@ -456,8 +473,10 @@ package.
 
 -   Add {Rapp} as a dependency in your DESCRIPTION.
 
--   Place your app in the `exec` folder in your package (for example
-    `exec/myapp`). Apps are automatically installed as executables.
+-   Place your app in the `exec` folder in your package as an `.R` script
+    with a `Rapp` or `Rscript` shebang line (for example,
+    `exec/myapp.R`). `install_pkg_cli_apps()` installs it as `myapp` by
+    default.
 
 -   Encourage users to run `Rapp::install_pkg_cli_apps("mypackage")` or
     your own exported wrapper `mypackage::install_mypackage_cli()` after

--- a/man/install_pkg_cli_apps.Rd
+++ b/man/install_pkg_cli_apps.Rd
@@ -36,19 +36,22 @@ Invisibly returns the paths of launchers that were (re)written.
 \code{.R} scripts whose shebang line invokes \code{Rapp} (for example, \verb{#!/usr/bin/env Rapp}) or \code{Rscript} (for example, \verb{#!/usr/bin/env Rscript}). Each discovered
 script gets a lightweight launcher in \code{destdir} that invokes \code{Rapp} or
 \code{Rscript} to run the app. The launcher encodes the absolute path to the R
-binary this function is called from.
+binary this function is called from, and its name defaults to the script
+basename without the \code{.R} extension.
 }
 \details{
-Optional \verb{#| launcher:} front matter in the script lets authors tune the
-\code{Rscript} flags. By default, for both \code{Rscript} and \code{Rapp}, R is invoked with
-\verb{--default-packages=base,<pkg>}, where \verb{<pkg>} is the package providing the
-executable.
+Optional \verb{#| launcher:} front matter in the script lets authors set the
+installed launcher \code{name} and tune the \code{Rscript} flags. By default, package
+apps are invoked with \verb{--default-packages=base,<pkg>}, where \verb{<pkg>} is the
+package providing the executable. The top-level \code{Rapp} launcher installed by
+\code{install_pkg_cli_apps("Rapp")} invokes \verb{Rscript -e Rapp::run()} without
+package app defaults.
 
 Launchers are regenerated each time \code{install_pkg_cli_apps()} is called, and
-any obsolete launchers for the same package are removed. \code{RAPP_INSTALL_DIR}
+any obsolete launchers for the same package are removed. \code{RAPP_BIN_DIR}
 overrides the default destination. Launchers are POSIX shell scripts on
 Unix-like systems and \code{.bat} files on Windows. Front-matter options such as
-\code{vanilla}, \code{no-environ}, and \code{default_packages} map directly to the
+\code{name}, \code{vanilla}, \code{no-environ}, and \code{default-packages} map directly to the
 corresponding \code{Rscript} arguments.
 
 When \code{overwrite} is \code{NA}, files previously written by Rapp are always
@@ -58,7 +61,7 @@ executable.
 
 If \code{destdir} is not provided, it is resolved in this order:
 \itemize{
-\item env var \code{RAPP_INSTALL_DIR}
+\item env var \code{RAPP_BIN_DIR}
 \item env var \code{XDG_BIN_HOME}
 \item env var \code{XDG_DATA_HOME/../bin}
 \item the default location:
@@ -82,6 +85,7 @@ Example setting \code{launcher} args:
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{#!/usr/bin/env Rapp
 #| description: About this app
 #| launcher:
+#|   name: about
 #|   vanilla: true
 #|   default-packages: [base, utils, mypkg]
 }\if{html}{\out{</div>}}

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -277,6 +277,48 @@ test_that("front matter customises launcher options", {
 })
 
 
+test_that("launcher front matter accepts kebab-case option names", {
+  withr::local_envvar(RAPP_NO_MODIFY_PATH = "1")
+
+  pkg <- "rappTestLauncherKebab"
+  fake <- setup_fake_rapp_package(
+    tempdir(),
+    "-install-launcher-kebab",
+    package = pkg
+  )
+  on.exit(unlink(fake[["lib"]], recursive = TRUE), add = TRUE)
+
+  app_path <- file.path(fake[["exec"]], "kebab.R")
+  writeLines(
+    c(
+      "#!/usr/bin/env Rapp",
+      "#| launcher:",
+      "#|   default-packages: [stats]",
+      "print('launcher kebab test')"
+    ),
+    app_path
+  )
+
+  destdir <- tempfile("rapp-bin-launcher-kebab")
+  on.exit(unlink(destdir, recursive = TRUE), add = TRUE)
+
+  created <- suppressMessages(
+    install_pkg_cli_apps(pkg, destdir = destdir, lib.loc = fake[["lib"]])
+  )
+
+  expected_launcher <- if (is_windows()) {
+    path(destdir, "kebab.bat")
+  } else {
+    path(destdir, "kebab")
+  }
+  expect_same_path(created, expected_launcher)
+
+  exec_line <- tail(readLines(expected_launcher), 1L)
+  expect_true(grepl("--default-packages=stats", exec_line, fixed = TRUE))
+  expect_false(grepl(paste0("base,", pkg), exec_line, fixed = TRUE))
+})
+
+
 test_that("launcher-like front matter keys do not partially match", {
   withr::local_envvar(RAPP_NO_MODIFY_PATH = "1")
 


### PR DESCRIPTION
## Summary

Clarifies package launcher installation because the current docs describe stale installer behavior and do not make the required `exec/*.R` convention obvious.

Closes #19.
Closes #20.

## User-facing changes

- Documents that packaged apps are discovered as `.R` scripts under `exec/`.
- Documents that `exec/myapp.R` installs as the extensionless `myapp` launcher by default.
- Replaces stale `RAPP_INSTALL_DIR` references with `RAPP_BIN_DIR`.
- Documents `#| launcher:` options for changing the installed command name and generated `Rscript` invocation.

## Internal changes

- Normalizes launcher front-matter keys so documented kebab-case options such as `default-packages` are honored.
- Adds a regression test for kebab-case launcher options.
- Regenerates `man/install_pkg_cli_apps.Rd` with `devtools::document()`.
